### PR TITLE
Remove excess category info from products

### DIFF
--- a/server/data/products/v2.0/categories/categories.json
+++ b/server/data/products/v2.0/categories/categories.json
@@ -1,1 +1,211 @@
-{"status":"ok","meta":{"offset":0,"limit":1,"count":1,"total":1},"data":[{"id":"faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9","title":"Drinks Cabinet","box_limit":7,"is_default":false,"recently_added":false,"hidden":false},{"id":"529ea59e-bf7e-11e5-840e-02fada0dd3b9","title":"Kitchenware","box_limit":6,"is_default":false,"recently_added":false,"hidden":false},{"id":"fec10d0e-bf7d-11e5-90a9-02fada0dd3b9","title":"Desserts","box_limit":4,"is_default":false,"recently_added":false,"hidden":false},{"id":"01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9","title":"Food Cupboard","box_limit":10,"is_default":false,"recently_added":false,"hidden":false},{"id":"17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9","title":"Snacks","box_limit":10,"is_default":false,"recently_added":false,"hidden":false},{"id":"c2b64b58-5280-11e6-b304-02cd0b1dc697","title":"Kids","box_limit":5,"is_default":false,"recently_added":false,"hidden":false},{"id":"287ad10e-e186-11e6-86d4-0297f19e8e45","title":"Valentines","box_limit":2,"is_default":false,"recently_added":false,"hidden":false},{"id":"384da59c-9452-11e6-87b0-06981aa90cf9","title":"Christmas","box_limit":2,"is_default":false,"recently_added":false,"hidden":false},{"id":"831b3f8a-3854-11e6-86cf-06f9522b85fb","title":"Small BakedIn","box_limit":2,"is_default":false,"recently_added":false,"hidden":true},{"id":"4cb35a02-27da-11e6-bf1e-026e15ef4a55","title":"Lunch","box_limit":5,"is_default":false,"recently_added":false,"hidden":false},{"id":"4dd32756-d12e-11e7-b28b-0617e74d8914","title":"Christmas md","box_limit":3,"is_default":false,"recently_added":false,"hidden":true},{"id":"a44b4c22-e489-11e6-9d77-027ca04bdf39","title":"Most Popular","box_limit":2,"is_default":false,"recently_added":false,"hidden":false},{"id":"89e489de-3854-11e6-ae7c-06f9522b85fb","title":"Large Breakfast","box_limit":1,"is_default":false,"recently_added":false,"hidden":true},{"id":"7867356c-3854-11e6-ab35-06f9522b85fb","title":"Mini Alcohol","box_limit":5,"is_default":false,"recently_added":false,"hidden":true},{"id":"dd25600c-97c9-11e7-b173-067ba2f0c390","title":"Free from","box_limit":4,"is_default":false,"recently_added":false,"hidden":false},{"id":"830f0a62-3854-11e6-8999-06f9522b85fb","title":"Large BakedIn","box_limit":1,"is_default":false,"recently_added":false,"hidden":true},{"id":"48dc8dc2-27da-11e6-9902-026e15ef4a55","title":"Breakfast","box_limit":6,"is_default":false,"recently_added":false,"hidden":false},{"id":"47d0e046-d12e-11e7-aba4-0617e74d8914","title":"Christmas sm","box_limit":4,"is_default":false,"recently_added":false,"hidden":true},{"id":"83281818-3854-11e6-8771-06f9522b85fb","title":"Mug BakedIn","box_limit":4,"is_default":false,"recently_added":false,"hidden":true},{"id":"785741fc-3854-11e6-87a5-06f9522b85fb","title":"Large Alcohol","box_limit":2,"is_default":false,"recently_added":false,"hidden":true},{"id":"52a565d2-d12e-11e7-a210-0617e74d8914","title":"Christmas lg","box_limit":2,"is_default":false,"recently_added":false,"hidden":true},{"id":"8b349cfc-ff3c-11e6-bf7e-02d1dd7f0ccb","title":"Easter","box_limit":4,"is_default":false,"recently_added":false,"hidden":false},{"id":"89f0f70a-3854-11e6-8218-06f9522b85fb","title":"Small Breakfast","box_limit":5,"is_default":false,"recently_added":false,"hidden":true},{"id":"8302b6ae-3854-11e6-9e42-06f9522b85fb","title":"Little Pot","box_limit":4,"is_default":false,"recently_added":false,"hidden":true},{"id":"f76c6640-97c9-11e7-aecd-067ba2f0c390","title":"Small free from","box_limit":2,"is_default":false,"recently_added":false,"hidden":true}]}
+{
+  "status": "ok",
+  "meta": {
+    "offset": 0,
+    "limit": 1,
+    "count": 1,
+    "total": 1
+  },
+  "data": [
+    {
+      "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+      "title": "Drinks Cabinet",
+      "box_limit": 7,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": false
+    },
+    {
+      "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
+      "title": "Kitchenware",
+      "box_limit": 6,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": false
+    },
+    {
+      "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+      "title": "Desserts",
+      "box_limit": 4,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": false
+    },
+    {
+      "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
+      "title": "Food Cupboard",
+      "box_limit": 10,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": false
+    },
+    {
+      "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+      "title": "Snacks",
+      "box_limit": 10,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": false
+    },
+    {
+      "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
+      "title": "Kids",
+      "box_limit": 5,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": false
+    },
+    {
+      "id": "287ad10e-e186-11e6-86d4-0297f19e8e45",
+      "title": "Valentines",
+      "box_limit": 2,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": false
+    },
+    {
+      "id": "384da59c-9452-11e6-87b0-06981aa90cf9",
+      "title": "Christmas",
+      "box_limit": 2,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": false
+    },
+    {
+      "id": "831b3f8a-3854-11e6-86cf-06f9522b85fb",
+      "title": "Small BakedIn",
+      "box_limit": 2,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": true
+    },
+    {
+      "id": "4cb35a02-27da-11e6-bf1e-026e15ef4a55",
+      "title": "Lunch",
+      "box_limit": 5,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": false
+    },
+    {
+      "id": "4dd32756-d12e-11e7-b28b-0617e74d8914",
+      "title": "Christmas md",
+      "box_limit": 3,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": true
+    },
+    {
+      "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
+      "title": "Most Popular",
+      "box_limit": 2,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": false
+    },
+    {
+      "id": "89e489de-3854-11e6-ae7c-06f9522b85fb",
+      "title": "Large Breakfast",
+      "box_limit": 1,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": true
+    },
+    {
+      "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
+      "title": "Mini Alcohol",
+      "box_limit": 5,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": true
+    },
+    {
+      "id": "dd25600c-97c9-11e7-b173-067ba2f0c390",
+      "title": "Free from",
+      "box_limit": 4,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": false
+    },
+    {
+      "id": "830f0a62-3854-11e6-8999-06f9522b85fb",
+      "title": "Large BakedIn",
+      "box_limit": 1,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": true
+    },
+    {
+      "id": "48dc8dc2-27da-11e6-9902-026e15ef4a55",
+      "title": "Breakfast",
+      "box_limit": 6,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": false
+    },
+    {
+      "id": "47d0e046-d12e-11e7-aba4-0617e74d8914",
+      "title": "Christmas sm",
+      "box_limit": 4,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": true
+    },
+    {
+      "id": "83281818-3854-11e6-8771-06f9522b85fb",
+      "title": "Mug BakedIn",
+      "box_limit": 4,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": true
+    },
+    {
+      "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
+      "title": "Large Alcohol",
+      "box_limit": 2,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": true
+    },
+    {
+      "id": "52a565d2-d12e-11e7-a210-0617e74d8914",
+      "title": "Christmas lg",
+      "box_limit": 2,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": true
+    },
+    {
+      "id": "8b349cfc-ff3c-11e6-bf7e-02d1dd7f0ccb",
+      "title": "Easter",
+      "box_limit": 4,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": false
+    },
+    {
+      "id": "89f0f70a-3854-11e6-8218-06f9522b85fb",
+      "title": "Small Breakfast",
+      "box_limit": 5,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": true
+    },
+    {
+      "id": "8302b6ae-3854-11e6-9e42-06f9522b85fb",
+      "title": "Little Pot",
+      "box_limit": 4,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": true
+    },
+    {
+      "id": "f76c6640-97c9-11e7-aecd-067ba2f0c390",
+      "title": "Small free from",
+      "box_limit": 2,
+      "is_default": false,
+      "recently_added": false,
+      "hidden": true
+    }
+  ]
+}

--- a/server/data/products/v2.0/products/products.json
+++ b/server/data/products/v2.0/products/products.json
@@ -22,28 +22,8 @@
             "zone": "Ambient",
             "created_at": "2017-05-08T13:22:27+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:22:46+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:22:46+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -69,17 +49,7 @@
             "zone": null,
             "created_at": "2017-11-02T16:22:21+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-12-29T14:55:56+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -105,28 +75,8 @@
             "zone": "Ambient",
             "created_at": "2018-03-13T16:53:07+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-13T16:54:41+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-03-13T16:54:41+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -174,17 +124,7 @@
             "zone": "Ambient",
             "created_at": "2019-09-10T10:54:41+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-09-10T10:55:29+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -210,39 +150,9 @@
             "zone": null,
             "created_at": "2016-08-16T13:19:07+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T12:32:39+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-31T12:32:39+01:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-02-08T09:49:46+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -268,28 +178,8 @@
             "zone": null,
             "created_at": "2016-10-13T09:25:42+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-10-13T09:26:04+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-10-13T09:26:04+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -315,28 +205,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:43:37+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:45:26+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:45:26+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -362,28 +232,8 @@
             "zone": "Ambient",
             "created_at": "2017-05-08T13:15:28+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:15:53+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:15:53+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -409,28 +259,8 @@
             "zone": "Ambient",
             "created_at": "2017-03-06T10:59:52+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:45:36+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:45:36+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -456,50 +286,10 @@
             "zone": null,
             "created_at": "2017-03-06T10:52:43+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T12:05:39+00:00"
-                    }
-                },
-                {
-                    "id": "830f0a62-3854-11e6-8999-06f9522b85fb",
-                    "title": "Large BakedIn",
-                    "box_limit": 1,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-03-06T12:05:39+00:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-31T12:06:15+01:00"
-                    }
-                },
-                {
-                    "id": "8b349cfc-ff3c-11e6-bf7e-02d1dd7f0ccb",
-                    "title": "Easter",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T12:05:39+00:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "830f0a62-3854-11e6-8999-06f9522b85fb",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39",
+                "8b349cfc-ff3c-11e6-bf7e-02d1dd7f0ccb"
             ],
             "tags": [],
             "images": {
@@ -525,17 +315,7 @@
             "zone": null,
             "created_at": "2017-03-06T12:04:19+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-08T09:56:35+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -561,39 +341,9 @@
             "zone": null,
             "created_at": "2016-07-22T09:02:35+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-07-03T15:19:04+01:00"
-                    }
-                },
-                {
-                    "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
-                    "title": "Kids",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T16:49:52+01:00"
-                    }
-                },
-                {
-                    "id": "dd25600c-97c9-11e7-b173-067ba2f0c390",
-                    "title": "Free from",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-19T10:57:36+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "c2b64b58-5280-11e6-b304-02cd0b1dc697",
+                "dd25600c-97c9-11e7-b173-067ba2f0c390"
             ],
             "tags": [],
             "images": {
@@ -619,28 +369,8 @@
             "zone": "Ambient",
             "created_at": "2019-06-14T14:05:07+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-06-14T14:12:31+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-06-14T14:12:31+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -666,17 +396,7 @@
             "zone": "Ambient",
             "created_at": "2019-05-01T10:25:18+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-05-01T10:27:00+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -702,17 +422,7 @@
             "zone": "Ambient",
             "created_at": "2016-05-10T13:28:10+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-18T14:10:59+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -738,17 +448,7 @@
             "zone": null,
             "created_at": "2016-05-11T13:55:38+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T11:57:59+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -774,17 +474,7 @@
             "zone": "Ambient",
             "created_at": "2016-12-20T11:54:20+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-12-04T12:30:55+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -810,17 +500,7 @@
             "zone": "Ambient",
             "created_at": "2018-07-19T09:30:50+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-09T10:32:14+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -846,50 +526,10 @@
             "zone": "Ambient",
             "created_at": "2017-02-13T11:39:14+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-02-13T11:40:32+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-02-13T11:40:32+00:00"
-                    }
-                },
-                {
-                    "id": "287ad10e-e186-11e6-86d4-0297f19e8e45",
-                    "title": "Valentines",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-02-13T11:40:32+00:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-02-13T11:40:32+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb",
+                "287ad10e-e186-11e6-86d4-0297f19e8e45",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -937,28 +577,8 @@
             "zone": null,
             "created_at": "2016-06-15T10:58:11+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:52:05+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:52:05+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -984,17 +604,7 @@
             "zone": null,
             "created_at": "2016-08-16T12:57:56+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-30T09:59:10+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1042,17 +652,7 @@
             "zone": "Ambient",
             "created_at": "2018-11-09T13:26:28+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-19T13:12:27+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1078,17 +678,7 @@
             "zone": "Ambient",
             "created_at": "2018-08-09T11:07:46+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-12-04T12:33:30+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1114,17 +704,7 @@
             "zone": null,
             "created_at": "2016-08-16T13:05:11+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T10:13:30+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1150,17 +730,7 @@
             "zone": null,
             "created_at": "2016-05-10T13:21:12+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T13:59:19+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1186,17 +756,7 @@
             "zone": "Ambient",
             "created_at": "2016-03-15T17:26:34+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T13:56:32+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1222,39 +782,9 @@
             "zone": null,
             "created_at": "2016-11-14T11:25:38+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-11-14T11:28:40+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-11-15T14:23:11+00:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-04-28T13:28:00+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -1280,28 +810,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T16:46:44+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:02:32+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:02:32+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -1327,17 +837,7 @@
             "zone": null,
             "created_at": "2016-03-31T15:41:47+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-22T13:44:22+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1363,28 +863,8 @@
             "zone": "Ambient",
             "created_at": "2019-08-09T12:44:43+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-09T12:47:51+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-08-09T12:47:51+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -1410,17 +890,7 @@
             "zone": "Ambient",
             "created_at": "2019-09-10T10:40:56+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-09-10T10:47:48+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1446,28 +916,8 @@
             "zone": "Ambient",
             "created_at": "2019-04-05T09:44:56+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-09T09:35:42+01:00"
-                    }
-                },
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-09T09:35:42+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1493,17 +943,7 @@
             "zone": "Ambient",
             "created_at": "2019-08-12T16:08:50+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-12T16:09:08+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1551,28 +991,8 @@
             "zone": "Ambient",
             "created_at": "2018-03-13T15:13:33+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-13T15:14:16+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-03-13T15:14:16+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -1598,28 +1018,8 @@
             "zone": "Ambient",
             "created_at": "2017-05-08T13:37:28+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:37:47+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:37:47+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -1645,28 +1045,8 @@
             "zone": null,
             "created_at": "2016-03-31T08:46:45+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:52:19+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:52:19+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -1692,17 +1072,7 @@
             "zone": null,
             "created_at": "2016-06-28T10:50:16+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T11:58:53+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1750,28 +1120,8 @@
             "zone": null,
             "created_at": "2017-05-08T17:40:55+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T17:41:23+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T17:41:23+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -1797,28 +1147,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-09T11:39:26+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T18:16:31+00:00"
-                    }
-                },
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-03-27T16:06:24+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1844,17 +1174,7 @@
             "zone": "Ambient",
             "created_at": "2017-01-19T18:07:17+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-19T18:07:55+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1880,17 +1200,7 @@
             "zone": null,
             "created_at": "2017-03-15T14:38:54+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-15T14:42:14+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1916,28 +1226,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:30:00+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:30:22+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:30:22+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -1963,17 +1253,7 @@
             "zone": null,
             "created_at": "2016-08-05T09:43:51+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-30T09:59:32+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -1999,17 +1279,7 @@
             "zone": null,
             "created_at": "2017-03-06T10:53:22+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T12:06:26+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -2035,28 +1305,8 @@
             "zone": null,
             "created_at": "2017-03-06T11:00:33+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:43:15+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:43:15+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -2082,17 +1332,7 @@
             "zone": null,
             "created_at": "2016-05-11T13:56:12+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T09:23:38+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -2118,28 +1358,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:37:12+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:37:33+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:37:33+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -2165,17 +1385,7 @@
             "zone": null,
             "created_at": "2016-07-22T08:56:05+01:00",
             "categories": [
-                {
-                    "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
-                    "title": "Kids",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T09:22:06+01:00"
-                    }
-                }
+                "c2b64b58-5280-11e6-b304-02cd0b1dc697"
             ],
             "tags": [],
             "images": {
@@ -2201,17 +1411,7 @@
             "zone": null,
             "created_at": "2016-10-13T09:19:21+01:00",
             "categories": [
-                {
-                    "id": "384da59c-9452-11e6-87b0-06981aa90cf9",
-                    "title": "Christmas",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-12T11:42:17+00:00"
-                    }
-                }
+                "384da59c-9452-11e6-87b0-06981aa90cf9"
             ],
             "tags": [],
             "images": {
@@ -2259,17 +1459,7 @@
             "zone": "Ambient",
             "created_at": "2018-08-28T12:47:24+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-08-28T12:47:45+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -2315,28 +1505,8 @@
             "zone": null,
             "created_at": "2016-05-10T13:14:33+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:52:33+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:52:33+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -2362,28 +1532,8 @@
             "zone": null,
             "created_at": "2016-07-22T09:03:23+01:00",
             "categories": [
-                {
-                    "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
-                    "title": "Kids",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T08:39:29+01:00"
-                    }
-                },
-                {
-                    "id": "dd25600c-97c9-11e7-b173-067ba2f0c390",
-                    "title": "Free from",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-19T10:58:32+01:00"
-                    }
-                }
+                "c2b64b58-5280-11e6-b304-02cd0b1dc697",
+                "dd25600c-97c9-11e7-b173-067ba2f0c390"
             ],
             "tags": [],
             "images": {
@@ -2431,17 +1581,7 @@
             "zone": "Ambient",
             "created_at": "2019-08-09T10:14:56+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-09T10:16:04+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -2467,28 +1607,8 @@
             "zone": null,
             "created_at": "2016-11-14T11:26:15+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-11-14T11:29:25+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-11-15T14:23:26+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -2514,28 +1634,8 @@
             "zone": "Ambient",
             "created_at": "2017-09-05T11:22:45+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-06T15:38:33+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-09-06T15:38:33+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -2561,17 +1661,7 @@
             "zone": "Ambient",
             "created_at": "2017-08-08T17:03:47+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T17:04:15+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -2617,17 +1707,7 @@
             "zone": null,
             "created_at": "2017-11-28T11:56:29+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-12-29T15:01:19+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -2653,28 +1733,8 @@
             "zone": "Chilled",
             "created_at": "2017-05-08T16:08:18+01:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-09-25T14:58:32+01:00"
-                    }
-                },
-                {
-                    "id": "dd25600c-97c9-11e7-b173-067ba2f0c390",
-                    "title": "Free from",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-19T10:57:18+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "dd25600c-97c9-11e7-b173-067ba2f0c390"
             ],
             "tags": [],
             "images": {
@@ -2700,17 +1760,7 @@
             "zone": "Ambient",
             "created_at": "2018-04-09T08:54:02+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-12-04T12:33:00+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -2736,17 +1786,7 @@
             "zone": null,
             "created_at": "2017-11-22T14:41:05+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-11-22T18:14:47+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -2772,28 +1812,8 @@
             "zone": null,
             "created_at": "2016-05-25T11:45:27+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T07:55:10+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-30T07:55:10+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -2819,28 +1839,8 @@
             "zone": "Ambient",
             "created_at": "2019-08-09T12:52:34+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-09T12:53:16+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-08-09T12:53:16+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -2866,17 +1866,7 @@
             "zone": null,
             "created_at": "2016-08-16T12:51:39+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T09:58:02+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -2898,28 +1888,8 @@
             "zone": "Chilled",
             "created_at": "2019-05-28T17:03:47+01:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-05-28T17:05:40+01:00"
-                    }
-                },
-                {
-                    "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
-                    "title": "Kids",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-05-28T17:05:40+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "c2b64b58-5280-11e6-b304-02cd0b1dc697"
             ],
             "tags": [],
             "images": {
@@ -2945,17 +1915,7 @@
             "zone": null,
             "created_at": "2017-03-29T09:24:50+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-29T09:28:29+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -2981,28 +1941,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-09T12:51:30+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-09T12:52:00+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-09T12:52:00+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -3028,28 +1968,8 @@
             "zone": "Ambient",
             "created_at": "2017-07-19T12:05:32+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-07-19T12:06:16+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-07-19T12:06:16+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -3075,17 +1995,7 @@
             "zone": null,
             "created_at": "2016-10-13T09:05:28+01:00",
             "categories": [
-                {
-                    "id": "384da59c-9452-11e6-87b0-06981aa90cf9",
-                    "title": "Christmas",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-10-18T15:23:20+01:00"
-                    }
-                }
+                "384da59c-9452-11e6-87b0-06981aa90cf9"
             ],
             "tags": [],
             "images": {
@@ -3111,17 +2021,7 @@
             "zone": null,
             "created_at": "2016-06-28T10:50:54+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T08:49:37+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -3147,17 +2047,7 @@
             "zone": null,
             "created_at": "2016-05-10T13:22:04+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T14:00:56+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -3183,17 +2073,7 @@
             "zone": null,
             "created_at": "2016-07-21T10:30:47+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-10T08:22:51+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -3261,39 +2141,9 @@
             "zone": null,
             "created_at": "2016-02-17T12:15:56+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T12:00:50+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-16T12:00:50+01:00"
-                    }
-                },
-                {
-                    "id": "384da59c-9452-11e6-87b0-06981aa90cf9",
-                    "title": "Christmas",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-11-03T17:29:27+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb",
+                "384da59c-9452-11e6-87b0-06981aa90cf9"
             ],
             "tags": [],
             "images": {
@@ -3319,17 +2169,7 @@
             "zone": "Ambient",
             "created_at": "2019-08-12T15:55:19+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-12T15:57:05+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -3355,28 +2195,8 @@
             "zone": null,
             "created_at": "2017-03-06T11:01:09+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:44:25+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:44:25+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -3402,28 +2222,8 @@
             "zone": "Ambient",
             "created_at": "2016-08-16T13:13:22+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T08:50:26+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-30T08:50:26+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -3449,28 +2249,8 @@
             "zone": null,
             "created_at": "2017-11-08T16:09:33+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-11-08T16:59:14+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-11-08T16:59:14+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -3496,28 +2276,8 @@
             "zone": null,
             "created_at": "2016-10-13T09:27:07+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-10-14T14:56:43+01:00"
-                    }
-                },
-                {
-                    "id": "384da59c-9452-11e6-87b0-06981aa90cf9",
-                    "title": "Christmas",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-10-18T15:37:49+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "384da59c-9452-11e6-87b0-06981aa90cf9"
             ],
             "tags": [],
             "images": {
@@ -3563,17 +2323,7 @@
             "zone": "Ambient",
             "created_at": "2016-07-25T17:15:17+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-03-13T17:44:04+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -3599,28 +2349,8 @@
             "zone": null,
             "created_at": "2017-05-08T17:48:51+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T17:49:18+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T17:49:18+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -3646,28 +2376,8 @@
             "zone": null,
             "created_at": "2017-03-06T10:54:07+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T12:12:00+00:00"
-                    }
-                },
-                {
-                    "id": "8b349cfc-ff3c-11e6-bf7e-02d1dd7f0ccb",
-                    "title": "Easter",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-19T15:29:04+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "8b349cfc-ff3c-11e6-bf7e-02d1dd7f0ccb"
             ],
             "tags": [],
             "images": {
@@ -3693,28 +2403,8 @@
             "zone": "Chilled",
             "created_at": "2019-03-14T13:36:52+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-29T10:29:19+01:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-12T13:08:00+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -3760,28 +2450,8 @@
             "zone": "Ambient",
             "created_at": "2017-05-08T13:24:06+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:24:27+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:24:27+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -3807,28 +2477,8 @@
             "zone": "Ambient",
             "created_at": "2019-06-14T13:02:07+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-06-14T13:06:46+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-06-14T13:06:46+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -3854,28 +2504,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-09T12:59:02+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-09T13:02:18+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-09T13:02:18+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -3923,28 +2553,8 @@
             "zone": "Ambient",
             "created_at": "2016-05-10T13:15:16+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:52:51+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:52:51+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -3970,28 +2580,8 @@
             "zone": null,
             "created_at": "2016-03-31T08:54:54+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T13:54:05+01:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-30T10:46:19+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -4017,17 +2607,7 @@
             "zone": "Ambient",
             "created_at": "2017-08-08T16:35:42+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:36:15+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -4075,39 +2655,9 @@
             "zone": null,
             "created_at": "2016-11-14T11:26:54+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-11-14T11:29:59+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-11-15T14:23:42+00:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-02-16T17:44:07+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -4133,28 +2683,8 @@
             "zone": "Ambient",
             "created_at": "2018-03-13T14:31:41+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-19T13:42:16+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-03-19T13:42:16+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -4180,17 +2710,7 @@
             "zone": "Chilled",
             "created_at": "2019-05-28T17:18:42+01:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-05-28T17:19:58+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -4216,28 +2736,8 @@
             "zone": "Ambient",
             "created_at": "2016-06-15T10:59:41+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T12:44:01+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-31T12:44:01+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -4285,39 +2785,9 @@
             "zone": null,
             "created_at": "2017-06-12T14:23:02+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-07-03T15:19:18+01:00"
-                    }
-                },
-                {
-                    "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
-                    "title": "Kids",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-06-12T14:23:38+01:00"
-                    }
-                },
-                {
-                    "id": "dd25600c-97c9-11e7-b173-067ba2f0c390",
-                    "title": "Free from",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-19T10:57:43+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "c2b64b58-5280-11e6-b304-02cd0b1dc697",
+                "dd25600c-97c9-11e7-b173-067ba2f0c390"
             ],
             "tags": [],
             "images": {
@@ -4343,28 +2813,8 @@
             "zone": "Ambient",
             "created_at": "2017-05-08T17:42:03+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T17:42:23+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T17:42:23+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -4412,28 +2862,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T15:59:32+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T15:59:54+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-20T15:59:54+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -4459,28 +2889,8 @@
             "zone": "Ambient",
             "created_at": "2017-05-08T13:17:15+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:17:44+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:17:44+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -4506,28 +2916,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:38:17+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:38:38+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:38:38+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -4553,17 +2943,7 @@
             "zone": null,
             "created_at": "2016-06-28T10:51:32+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T08:48:34+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -4589,17 +2969,7 @@
             "zone": "Ambient",
             "created_at": "2017-03-06T11:51:48+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-12T12:41:05+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -4625,28 +2995,8 @@
             "zone": null,
             "created_at": "2017-08-08T16:50:22+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:50:54+01:00"
-                    }
-                },
-                {
-                    "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
-                    "title": "Kids",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:50:54+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "c2b64b58-5280-11e6-b304-02cd0b1dc697"
             ],
             "tags": [],
             "images": {
@@ -4672,28 +3022,8 @@
             "zone": "Ambient",
             "created_at": "2018-01-23T18:14:44+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-01-26T10:54:33+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-01-26T10:54:33+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -4719,17 +3049,7 @@
             "zone": null,
             "created_at": "2017-01-19T17:47:05+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-19T17:56:02+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -4755,28 +3075,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T14:48:08+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-12-11T09:39:43+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-12-11T09:39:57+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -4802,28 +3102,8 @@
             "zone": "Ambient",
             "created_at": "2017-03-06T11:01:49+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:47:34+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:47:34+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -4849,17 +3129,7 @@
             "zone": null,
             "created_at": "2017-11-02T17:50:21+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-12-29T15:03:25+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -4885,17 +3155,7 @@
             "zone": null,
             "created_at": "2016-10-18T08:53:12+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-10-19T08:38:35+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -4921,28 +3181,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:31:20+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:31:49+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:31:49+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -4990,28 +3230,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T15:16:53+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T15:17:16+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-20T15:17:16+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -5037,17 +3257,7 @@
             "zone": null,
             "created_at": "2016-07-28T12:53:43+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T10:10:49+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -5073,28 +3283,8 @@
             "zone": null,
             "created_at": "2016-03-31T08:48:18+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:53:15+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:53:15+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -5120,17 +3310,7 @@
             "zone": "Ambient",
             "created_at": "2016-10-04T12:51:50+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-10-04T12:55:35+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -5176,39 +3356,9 @@
             "zone": null,
             "created_at": "2016-10-13T09:27:54+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-10-13T10:43:44+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-10-13T10:43:44+01:00"
-                    }
-                },
-                {
-                    "id": "384da59c-9452-11e6-87b0-06981aa90cf9",
-                    "title": "Christmas",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-10-18T15:33:53+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb",
+                "384da59c-9452-11e6-87b0-06981aa90cf9"
             ],
             "tags": [],
             "images": {
@@ -5256,28 +3406,8 @@
             "zone": "Ambient",
             "created_at": "2016-05-10T13:15:57+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T12:43:17+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-31T12:43:17+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -5325,17 +3455,7 @@
             "zone": null,
             "created_at": "2017-03-09T15:23:25+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-10T11:40:07+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -5361,28 +3481,8 @@
             "zone": "Ambient",
             "created_at": "2016-11-08T11:20:23+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-11-08T11:27:35+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-11-08T11:27:35+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -5430,17 +3530,7 @@
             "zone": "Ambient",
             "created_at": "2019-08-09T10:09:08+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-09T10:09:23+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -5466,28 +3556,8 @@
             "zone": null,
             "created_at": "2016-06-15T11:00:18+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T16:51:29+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-16T16:51:29+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -5513,28 +3583,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T16:28:44+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T16:29:13+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-20T16:29:13+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -5560,17 +3610,7 @@
             "zone": null,
             "created_at": "2016-06-28T10:52:05+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T08:49:48+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -5596,50 +3636,10 @@
             "zone": null,
             "created_at": "2017-08-08T16:29:24+01:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:29:53+01:00"
-                    }
-                },
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:29:53+01:00"
-                    }
-                },
-                {
-                    "id": "831b3f8a-3854-11e6-86cf-06f9522b85fb",
-                    "title": "Small BakedIn",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:29:53+01:00"
-                    }
-                },
-                {
-                    "id": "dd25600c-97c9-11e7-b173-067ba2f0c390",
-                    "title": "Free from",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-19T10:58:15+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "831b3f8a-3854-11e6-86cf-06f9522b85fb",
+                "dd25600c-97c9-11e7-b173-067ba2f0c390"
             ],
             "tags": [],
             "images": {
@@ -5689,17 +3689,7 @@
             "zone": null,
             "created_at": "2016-05-25T11:39:37+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-30T10:01:15+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -5725,17 +3715,7 @@
             "zone": null,
             "created_at": "2016-02-17T16:13:20+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-07-19T09:56:36+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -5761,28 +3741,8 @@
             "zone": null,
             "created_at": "2017-11-22T12:26:29+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-11-23T11:10:46+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-11-23T11:10:46+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -5808,17 +3768,7 @@
             "zone": null,
             "created_at": "2016-12-15T10:00:55+00:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-12-15T10:56:34+00:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -5844,28 +3794,8 @@
             "zone": "Ambient",
             "created_at": "2018-03-13T15:08:22+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-13T15:09:23+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-03-13T15:09:23+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -5891,28 +3821,8 @@
             "zone": null,
             "created_at": "2017-05-08T13:10:48+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:11:20+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:11:20+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -5938,39 +3848,9 @@
             "zone": "Ambient",
             "created_at": "2016-08-16T13:07:23+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T11:31:26+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-31T11:31:26+01:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-08T10:57:31+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -5996,17 +3876,7 @@
             "zone": "Ambient",
             "created_at": "2019-08-12T16:18:05+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-12T16:18:40+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -6032,28 +3902,8 @@
             "zone": "Ambient",
             "created_at": "2018-03-13T14:39:50+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-13T14:40:41+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-03-13T14:40:41+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -6079,28 +3929,8 @@
             "zone": null,
             "created_at": "2017-11-08T16:10:50+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-11-08T16:58:57+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-11-08T16:58:57+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -6126,17 +3956,7 @@
             "zone": null,
             "created_at": "2017-11-08T13:11:54+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-12-29T15:05:52+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -6162,28 +3982,8 @@
             "zone": null,
             "created_at": "2016-08-16T13:00:22+01:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T10:10:02+01:00"
-                    }
-                },
-                {
-                    "id": "83281818-3854-11e6-8771-06f9522b85fb",
-                    "title": "Mug BakedIn",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-31T10:10:02+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "83281818-3854-11e6-8771-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -6209,28 +4009,8 @@
             "zone": "Ambient",
             "created_at": "2017-05-08T17:42:58+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T17:43:22+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T17:43:22+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -6256,17 +4036,7 @@
             "zone": "Ambient",
             "created_at": "2019-03-13T12:49:09+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-03-22T11:37:46+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -6292,17 +4062,7 @@
             "zone": null,
             "created_at": "2016-07-28T12:54:18+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T10:12:05+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -6328,17 +4088,7 @@
             "zone": null,
             "created_at": "2016-05-10T13:23:36+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T16:14:53+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -6364,28 +4114,8 @@
             "zone": "Ambient",
             "created_at": "2016-01-26T10:27:29+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-12T12:56:47+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-12T12:56:47+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -6411,28 +4141,8 @@
             "zone": null,
             "created_at": "2016-01-26T10:27:29+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-12T12:57:02+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-12T12:57:02+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -6458,28 +4168,8 @@
             "zone": null,
             "created_at": "2016-01-26T10:27:29+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-13T08:52:31+01:00"
-                    }
-                },
-                {
-                    "id": "287ad10e-e186-11e6-86d4-0297f19e8e45",
-                    "title": "Valentines",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-23T16:13:44+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
+                "287ad10e-e186-11e6-86d4-0297f19e8e45"
             ],
             "tags": [],
             "images": {
@@ -6505,17 +4195,7 @@
             "zone": null,
             "created_at": "2016-01-26T10:27:29+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-13T08:48:49+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -6541,28 +4221,8 @@
             "zone": null,
             "created_at": "2016-01-26T10:27:29+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-24T14:03:47+01:00"
-                    }
-                },
-                {
-                    "id": "830f0a62-3854-11e6-8999-06f9522b85fb",
-                    "title": "Large BakedIn",
-                    "box_limit": 1,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-24T14:03:47+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "830f0a62-3854-11e6-8999-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -6588,17 +4248,7 @@
             "zone": null,
             "created_at": "2016-01-26T10:27:29+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-13T08:49:38+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -6624,28 +4274,8 @@
             "zone": "Ambient",
             "created_at": "2018-03-13T14:18:29+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-13T14:19:36+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-03-13T14:19:36+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -6671,39 +4301,9 @@
             "zone": null,
             "created_at": "2017-03-06T11:02:35+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:48:09+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:48:09+00:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-23T12:27:35+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -6729,28 +4329,8 @@
             "zone": null,
             "created_at": "2016-08-16T13:14:48+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T11:33:45+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-31T11:33:45+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -6776,28 +4356,8 @@
             "zone": "Ambient",
             "created_at": "2016-10-04T12:52:29+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-10-04T12:56:43+01:00"
-                    }
-                },
-                {
-                    "id": "dd25600c-97c9-11e7-b173-067ba2f0c390",
-                    "title": "Free from",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-19T10:59:13+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "dd25600c-97c9-11e7-b173-067ba2f0c390"
             ],
             "tags": [],
             "images": {
@@ -6823,17 +4383,7 @@
             "zone": null,
             "created_at": "2017-01-19T18:02:17+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-19T18:03:05+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -6859,28 +4409,8 @@
             "zone": null,
             "created_at": "2016-06-15T11:00:47+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T16:50:41+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-16T16:50:41+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -6906,28 +4436,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:46:28+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:46:48+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:46:48+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -6953,17 +4463,7 @@
             "zone": "Ambient",
             "created_at": "2019-08-12T15:42:33+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-12T15:48:02+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -6989,28 +4489,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:39:21+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:39:45+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:39:45+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -7036,28 +4516,8 @@
             "zone": null,
             "created_at": "2016-06-15T10:53:43+01:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T09:00:02+01:00"
-                    }
-                },
-                {
-                    "id": "830f0a62-3854-11e6-8999-06f9522b85fb",
-                    "title": "Large BakedIn",
-                    "box_limit": 1,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-30T09:00:02+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "830f0a62-3854-11e6-8999-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -7083,28 +4543,8 @@
             "zone": null,
             "created_at": "2016-05-10T13:16:40+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:54:20+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:54:20+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -7130,39 +4570,9 @@
             "zone": "Ambient",
             "created_at": "2016-11-08T11:21:04+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-11-08T11:25:36+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-11-08T11:25:37+00:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-02-22T16:33:07+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -7188,39 +4598,9 @@
             "zone": null,
             "created_at": "2016-07-22T08:58:19+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-07-03T15:19:30+01:00"
-                    }
-                },
-                {
-                    "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
-                    "title": "Kids",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T16:52:22+01:00"
-                    }
-                },
-                {
-                    "id": "dd25600c-97c9-11e7-b173-067ba2f0c390",
-                    "title": "Free from",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-19T10:57:49+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "c2b64b58-5280-11e6-b304-02cd0b1dc697",
+                "dd25600c-97c9-11e7-b173-067ba2f0c390"
             ],
             "tags": [],
             "images": {
@@ -7246,17 +4626,7 @@
             "zone": "Ambient",
             "created_at": "2019-05-01T10:13:53+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-05-01T10:17:06+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -7282,39 +4652,9 @@
             "zone": null,
             "created_at": "2017-03-06T10:55:42+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T12:10:30+00:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-31T12:06:39+01:00"
-                    }
-                },
-                {
-                    "id": "8b349cfc-ff3c-11e6-bf7e-02d1dd7f0ccb",
-                    "title": "Easter",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T12:10:30+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39",
+                "8b349cfc-ff3c-11e6-bf7e-02d1dd7f0ccb"
             ],
             "tags": [],
             "images": {
@@ -7340,28 +4680,8 @@
             "zone": "Chilled",
             "created_at": "2019-08-05T15:51:03+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-05T15:51:53+01:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-05T15:51:53+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -7387,28 +4707,8 @@
             "zone": "Ambient",
             "created_at": "2018-03-13T16:56:18+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-13T16:57:12+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-03-13T16:57:12+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -7454,17 +4754,7 @@
             "zone": null,
             "created_at": "2016-10-13T09:28:53+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-10-19T08:41:46+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -7512,28 +4802,8 @@
             "zone": null,
             "created_at": "2017-05-08T13:32:55+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:33:23+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:33:23+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -7559,28 +4829,8 @@
             "zone": "Chilled",
             "created_at": "2019-03-14T13:38:34+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-29T11:35:54+01:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-12T13:08:14+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -7606,28 +4856,8 @@
             "zone": null,
             "created_at": "2017-09-05T11:24:56+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-06T15:38:07+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-09-06T15:38:07+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -7653,28 +4883,8 @@
             "zone": "Ambient",
             "created_at": "2018-03-13T14:26:08+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-13T14:28:57+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-03-13T14:28:57+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -7700,39 +4910,9 @@
             "zone": null,
             "created_at": "2016-07-28T12:54:51+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T10:12:44+01:00"
-                    }
-                },
-                {
-                    "id": "dd25600c-97c9-11e7-b173-067ba2f0c390",
-                    "title": "Free from",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-11-21T12:32:07+00:00"
-                    }
-                },
-                {
-                    "id": "f76c6640-97c9-11e7-aecd-067ba2f0c390",
-                    "title": "Small free from",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-11-21T12:32:07+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "dd25600c-97c9-11e7-b173-067ba2f0c390",
+                "f76c6640-97c9-11e7-aecd-067ba2f0c390"
             ],
             "tags": [],
             "images": {
@@ -7758,17 +4938,7 @@
             "zone": "Ambient",
             "created_at": "2019-08-12T16:11:35+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-12T16:11:57+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -7816,39 +4986,9 @@
             "zone": "Ambient",
             "created_at": "2016-08-16T13:08:14+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T11:33:18+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-31T11:33:18+01:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-09T11:00:52+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -7896,28 +5036,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:32:45+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:33:10+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:33:10+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -7943,28 +5063,8 @@
             "zone": null,
             "created_at": "2016-06-15T11:01:26+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-25T11:00:21+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-25T11:00:21+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -7990,17 +5090,7 @@
             "zone": "Ambient",
             "created_at": "2019-05-01T10:28:40+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-05-01T12:58:19+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -8026,17 +5116,7 @@
             "zone": null,
             "created_at": "2016-05-10T13:24:22+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T13:57:27+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -8062,28 +5142,8 @@
             "zone": "Ambient",
             "created_at": "2017-05-08T12:28:52+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T12:31:36+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T12:31:36+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -8109,17 +5169,7 @@
             "zone": "Ambient",
             "created_at": "2019-04-09T10:54:49+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-30T15:19:39+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -8145,17 +5195,7 @@
             "zone": "Ambient",
             "created_at": "2016-09-27T13:01:33+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-24T09:57:47+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -8181,28 +5221,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T14:42:34+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T14:43:49+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-20T14:43:49+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -8228,17 +5248,7 @@
             "zone": "Ambient",
             "created_at": "2017-11-03T15:49:08+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-01-08T09:26:31+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -8264,17 +5274,7 @@
             "zone": null,
             "created_at": "2016-05-19T11:33:38+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-05-25T12:45:13+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -8300,17 +5300,7 @@
             "zone": "Ambient",
             "created_at": "2019-08-09T10:17:38+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-09T10:18:01+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -8336,28 +5326,8 @@
             "zone": null,
             "created_at": "2016-08-16T13:15:41+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T11:32:23+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-31T11:32:23+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -8383,17 +5353,7 @@
             "zone": null,
             "created_at": "2016-08-05T09:39:42+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T09:56:14+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -8419,17 +5379,7 @@
             "zone": "Ambient",
             "created_at": "2016-12-15T10:02:07+00:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-12-15T10:57:01+00:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -8455,39 +5405,9 @@
             "zone": null,
             "created_at": "2016-07-28T12:55:19+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T10:12:55+01:00"
-                    }
-                },
-                {
-                    "id": "dd25600c-97c9-11e7-b173-067ba2f0c390",
-                    "title": "Free from",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-11-21T12:31:50+00:00"
-                    }
-                },
-                {
-                    "id": "f76c6640-97c9-11e7-aecd-067ba2f0c390",
-                    "title": "Small free from",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-11-21T12:31:50+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "dd25600c-97c9-11e7-b173-067ba2f0c390",
+                "f76c6640-97c9-11e7-aecd-067ba2f0c390"
             ],
             "tags": [],
             "images": {
@@ -8555,39 +5475,9 @@
             "zone": null,
             "created_at": "2017-08-08T16:45:01+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:45:22+01:00"
-                    }
-                },
-                {
-                    "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
-                    "title": "Kids",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:45:22+01:00"
-                    }
-                },
-                {
-                    "id": "dd25600c-97c9-11e7-b173-067ba2f0c390",
-                    "title": "Free from",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-19T10:58:43+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "c2b64b58-5280-11e6-b304-02cd0b1dc697",
+                "dd25600c-97c9-11e7-b173-067ba2f0c390"
             ],
             "tags": [],
             "images": {
@@ -8613,28 +5503,8 @@
             "zone": "Ambient",
             "created_at": "2018-03-13T14:12:20+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-13T14:15:35+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-03-13T14:15:35+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -8660,17 +5530,7 @@
             "zone": null,
             "created_at": "2016-03-15T17:22:50+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-05-12T09:07:50+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -8696,28 +5556,8 @@
             "zone": "Ambient",
             "created_at": "2018-03-13T16:42:40+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-13T16:43:57+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-03-13T16:43:57+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -8743,28 +5583,8 @@
             "zone": "Chilled",
             "created_at": "2019-03-14T13:39:10+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-29T11:37:12+01:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-12T13:08:28+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -8812,28 +5632,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-09T12:18:22+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-09T12:19:17+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-09T12:19:17+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -8881,39 +5681,9 @@
             "zone": null,
             "created_at": "2017-11-16T18:18:31+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-11-23T15:14:25+00:00"
-                    }
-                },
-                {
-                    "id": "384da59c-9452-11e6-87b0-06981aa90cf9",
-                    "title": "Christmas",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-11-23T15:14:25+00:00"
-                    }
-                },
-                {
-                    "id": "47d0e046-d12e-11e7-aba4-0617e74d8914",
-                    "title": "Christmas sm",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-11-24T15:50:41+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "384da59c-9452-11e6-87b0-06981aa90cf9",
+                "47d0e046-d12e-11e7-aba4-0617e74d8914"
             ],
             "tags": [],
             "images": {
@@ -8939,17 +5709,7 @@
             "zone": "Ambient",
             "created_at": "2016-07-14T13:12:01+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T13:53:19+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -8975,28 +5735,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T15:40:06+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T15:46:38+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-20T15:49:37+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -9022,28 +5762,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:47:27+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:47:45+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:47:45+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -9069,28 +5789,8 @@
             "zone": "Chilled",
             "created_at": "2018-11-09T14:34:26+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-09T14:39:36+00:00"
-                    }
-                },
-                {
-                    "id": "8302b6ae-3854-11e6-9e42-06f9522b85fb",
-                    "title": "Little Pot",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-09T14:39:36+00:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "8302b6ae-3854-11e6-9e42-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -9116,17 +5816,7 @@
             "zone": null,
             "created_at": "2016-08-30T09:53:12+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-09-07T13:24:19+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -9152,28 +5842,8 @@
             "zone": null,
             "created_at": "2016-03-31T08:50:06+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T09:01:45+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-30T09:01:45+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -9199,17 +5869,7 @@
             "zone": "Ambient",
             "created_at": "2019-08-09T10:03:36+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-09T10:04:34+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -9235,28 +5895,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T16:44:39+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T16:47:03+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-20T16:47:03+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -9282,17 +5922,7 @@
             "zone": null,
             "created_at": "2016-06-15T10:54:49+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T13:54:59+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -9362,17 +5992,7 @@
             "zone": null,
             "created_at": "2016-10-13T09:22:38+01:00",
             "categories": [
-                {
-                    "id": "384da59c-9452-11e6-87b0-06981aa90cf9",
-                    "title": "Christmas",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-12T11:41:16+00:00"
-                    }
-                }
+                "384da59c-9452-11e6-87b0-06981aa90cf9"
             ],
             "tags": [],
             "images": {
@@ -9398,28 +6018,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:40:32+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:40:56+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:40:56+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -9467,39 +6067,9 @@
             "zone": null,
             "created_at": "2017-03-09T15:25:13+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-10T11:40:27+00:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-31T12:07:16+01:00"
-                    }
-                },
-                {
-                    "id": "8b349cfc-ff3c-11e6-bf7e-02d1dd7f0ccb",
-                    "title": "Easter",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-09T15:27:25+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39",
+                "8b349cfc-ff3c-11e6-bf7e-02d1dd7f0ccb"
             ],
             "tags": [],
             "images": {
@@ -9525,28 +6095,8 @@
             "zone": "Ambient",
             "created_at": "2017-03-06T11:03:56+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:48:45+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:48:45+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -9572,17 +6122,7 @@
             "zone": "Ambient",
             "created_at": "2019-08-09T10:10:55+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-09T10:11:12+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -9608,17 +6148,7 @@
             "zone": null,
             "created_at": "2016-08-05T09:47:17+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T10:14:16+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -9644,17 +6174,7 @@
             "zone": "Ambient",
             "created_at": "2019-09-10T10:08:50+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-09-10T10:48:06+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -9680,28 +6200,8 @@
             "zone": "Ambient",
             "created_at": "2018-03-13T16:35:56+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-13T16:36:16+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-03-13T16:36:16+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -9727,28 +6227,8 @@
             "zone": null,
             "created_at": "2016-05-10T13:17:54+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:59:18+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:59:18+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -9794,28 +6274,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T15:19:01+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T15:19:27+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-20T15:19:27+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -9841,28 +6301,8 @@
             "zone": "Ambient",
             "created_at": "2016-08-16T13:09:05+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T12:30:44+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-31T12:30:44+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -9888,17 +6328,7 @@
             "zone": null,
             "created_at": "2017-03-09T15:46:50+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-09T15:55:54+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -9924,17 +6354,7 @@
             "zone": null,
             "created_at": "2017-02-24T16:59:32+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-02-24T17:08:28+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -9960,28 +6380,8 @@
             "zone": "Chilled",
             "created_at": "2018-11-09T14:56:18+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-09T14:56:54+00:00"
-                    }
-                },
-                {
-                    "id": "8302b6ae-3854-11e6-9e42-06f9522b85fb",
-                    "title": "Little Pot",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-09T14:56:54+00:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "8302b6ae-3854-11e6-9e42-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -10007,28 +6407,8 @@
             "zone": "Ambient",
             "created_at": "2017-05-08T13:19:42+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:20:03+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:20:03+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -10076,17 +6456,7 @@
             "zone": null,
             "created_at": "2017-01-19T18:10:54+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-19T18:11:49+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -10112,28 +6482,8 @@
             "zone": "Chilled",
             "created_at": "2019-03-14T13:39:41+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-29T11:37:58+01:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-12T13:08:38+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -10159,17 +6509,7 @@
             "zone": null,
             "created_at": "2016-05-25T11:41:31+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-30T10:26:31+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -10219,17 +6559,7 @@
             "zone": null,
             "created_at": "2016-08-30T09:53:40+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-09-07T13:25:47+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -10255,28 +6585,8 @@
             "zone": "Ambient",
             "created_at": "2017-11-03T12:36:35+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-12-29T15:12:40+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-12-29T15:12:40+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -10324,28 +6634,8 @@
             "zone": null,
             "created_at": "2017-09-05T11:26:11+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-06T15:30:03+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-09-06T15:30:03+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -10371,17 +6661,7 @@
             "zone": null,
             "created_at": "2016-07-28T12:48:53+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T10:10:23+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -10407,28 +6687,8 @@
             "zone": "Ambient",
             "created_at": "2017-03-06T10:57:09+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:49:46+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:49:46+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -10454,28 +6714,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T16:16:33+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T16:18:03+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-20T16:18:03+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -10501,28 +6741,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:33:51+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:34:06+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:34:06+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -10548,28 +6768,8 @@
             "zone": "Ambient",
             "created_at": "2018-03-13T15:10:25+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-13T15:12:27+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-03-13T15:12:27+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -10595,28 +6795,8 @@
             "zone": null,
             "created_at": "2017-08-08T16:53:02+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:53:17+01:00"
-                    }
-                },
-                {
-                    "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
-                    "title": "Kids",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:53:17+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "c2b64b58-5280-11e6-b304-02cd0b1dc697"
             ],
             "tags": [],
             "images": {
@@ -10642,17 +6822,7 @@
             "zone": null,
             "created_at": "2016-11-08T17:34:56+00:00",
             "categories": [
-                {
-                    "id": "384da59c-9452-11e6-87b0-06981aa90cf9",
-                    "title": "Christmas",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-11-14T10:43:57+00:00"
-                    }
-                }
+                "384da59c-9452-11e6-87b0-06981aa90cf9"
             ],
             "tags": [],
             "images": {
@@ -10678,28 +6848,8 @@
             "zone": "Ambient",
             "created_at": "2016-10-11T14:47:45+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-10-25T14:55:35+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-10-25T14:55:35+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -10747,17 +6897,7 @@
             "zone": null,
             "created_at": "2016-10-13T09:23:17+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-12-29T15:12:54+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -10805,39 +6945,9 @@
             "zone": null,
             "created_at": "2017-08-08T16:24:33+01:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:24:59+01:00"
-                    }
-                },
-                {
-                    "id": "831b3f8a-3854-11e6-86cf-06f9522b85fb",
-                    "title": "Small BakedIn",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:24:59+01:00"
-                    }
-                },
-                {
-                    "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
-                    "title": "Kids",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:24:59+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "831b3f8a-3854-11e6-86cf-06f9522b85fb",
+                "c2b64b58-5280-11e6-b304-02cd0b1dc697"
             ],
             "tags": [],
             "images": {
@@ -10863,17 +6973,7 @@
             "zone": "Ambient",
             "created_at": "2018-11-09T11:43:31+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T18:16:59+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -10921,28 +7021,8 @@
             "zone": null,
             "created_at": "2016-03-31T08:50:57+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:58:41+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:58:41+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -10990,28 +7070,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-09T13:09:32+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-09T13:10:23+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-09T13:10:23+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -11037,17 +7097,7 @@
             "zone": null,
             "created_at": "2017-03-09T15:47:28+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-09T15:57:01+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -11073,28 +7123,8 @@
             "zone": "Chilled",
             "created_at": "2019-03-14T13:40:16+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-29T11:38:52+01:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-12T13:08:48+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -11120,17 +7150,7 @@
             "zone": null,
             "created_at": "2016-07-21T10:20:11+01:00",
             "categories": [
-                {
-                    "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
-                    "title": "Kids",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T09:22:24+01:00"
-                    }
-                }
+                "c2b64b58-5280-11e6-b304-02cd0b1dc697"
             ],
             "tags": [],
             "images": {
@@ -11156,17 +7176,7 @@
             "zone": null,
             "created_at": "2016-06-28T10:54:38+01:00",
             "categories": [
-                {
-                    "id": "4cb35a02-27da-11e6-bf1e-026e15ef4a55",
-                    "title": "Lunch",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T12:13:46+01:00"
-                    }
-                }
+                "4cb35a02-27da-11e6-bf1e-026e15ef4a55"
             ],
             "tags": [],
             "images": {
@@ -11214,17 +7224,7 @@
             "zone": "Ambient",
             "created_at": "2019-09-10T10:45:23+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-09-10T10:47:34+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -11296,17 +7296,7 @@
             "zone": "Ambient",
             "created_at": "2016-09-27T13:10:12+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-12-04T12:32:09+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -11332,28 +7322,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:48:40+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:48:59+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:48:59+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -11379,28 +7349,8 @@
             "zone": "Chilled",
             "created_at": "2018-11-09T15:04:16+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-09T15:06:10+00:00"
-                    }
-                },
-                {
-                    "id": "8302b6ae-3854-11e6-9e42-06f9522b85fb",
-                    "title": "Little Pot",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-09T15:06:10+00:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "8302b6ae-3854-11e6-9e42-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -11426,17 +7376,7 @@
             "zone": null,
             "created_at": "2017-01-19T18:04:32+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-19T18:04:57+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -11462,17 +7402,7 @@
             "zone": null,
             "created_at": "2016-07-21T10:27:30+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T12:14:16+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -11498,28 +7428,8 @@
             "zone": "Ambient",
             "created_at": "2017-03-06T10:57:46+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:52:16+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:52:16+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -11545,17 +7455,7 @@
             "zone": "Ambient",
             "created_at": "2017-02-24T17:00:24+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-02-24T17:10:15+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -11581,28 +7481,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:41:37+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:41:50+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:41:50+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -11648,39 +7528,9 @@
             "zone": null,
             "created_at": "2017-08-08T16:46:30+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:46:45+01:00"
-                    }
-                },
-                {
-                    "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
-                    "title": "Kids",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:46:45+01:00"
-                    }
-                },
-                {
-                    "id": "dd25600c-97c9-11e7-b173-067ba2f0c390",
-                    "title": "Free from",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-19T10:58:53+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "c2b64b58-5280-11e6-b304-02cd0b1dc697",
+                "dd25600c-97c9-11e7-b173-067ba2f0c390"
             ],
             "tags": [],
             "images": {
@@ -11728,17 +7578,7 @@
             "zone": null,
             "created_at": "2017-03-15T14:36:17+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-15T14:42:42+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -11764,17 +7604,7 @@
             "zone": null,
             "created_at": "2017-03-06T10:50:46+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T12:11:32+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -11800,17 +7630,7 @@
             "zone": null,
             "created_at": "2017-11-22T14:30:57+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-11-22T18:20:07+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -11836,28 +7656,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-09T12:05:33+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-09T12:07:11+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-09T12:07:11+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -11883,17 +7683,7 @@
             "zone": null,
             "created_at": "2016-05-10T13:26:11+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T12:14:31+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -11919,39 +7709,9 @@
             "zone": null,
             "created_at": "2016-11-15T15:47:07+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-11-15T15:52:25+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-11-15T15:52:25+00:00"
-                    }
-                },
-                {
-                    "id": "384da59c-9452-11e6-87b0-06981aa90cf9",
-                    "title": "Christmas",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-11-15T16:23:22+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb",
+                "384da59c-9452-11e6-87b0-06981aa90cf9"
             ],
             "tags": [],
             "images": {
@@ -11977,17 +7737,7 @@
             "zone": "Ambient",
             "created_at": "2019-02-18T12:07:30+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-02-18T12:11:43+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -12013,28 +7763,8 @@
             "zone": null,
             "created_at": "2017-05-08T17:45:39+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T17:46:02+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T17:46:02+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -12060,28 +7790,8 @@
             "zone": null,
             "created_at": "2016-11-14T11:16:21+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-11-14T11:30:31+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-11-15T14:22:53+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -12107,28 +7817,8 @@
             "zone": "Ambient",
             "created_at": "2017-05-08T13:42:18+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:43:07+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:43:07+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -12154,28 +7844,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T16:10:18+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T16:10:38+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-20T16:10:38+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -12201,28 +7871,8 @@
             "zone": null,
             "created_at": "2017-09-05T11:27:12+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-06T15:28:05+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-09-06T15:28:05+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -12248,28 +7898,8 @@
             "zone": null,
             "created_at": "2016-03-31T08:51:39+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:58:19+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:58:19+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -12295,17 +7925,7 @@
             "zone": null,
             "created_at": "2017-03-29T09:14:53+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-29T09:29:41+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -12331,28 +7951,8 @@
             "zone": "Chilled",
             "created_at": "2019-03-14T13:40:55+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-29T11:39:32+01:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-12T13:08:58+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -12378,28 +7978,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T15:06:02+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T15:06:32+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-20T15:06:32+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -12425,17 +8005,7 @@
             "zone": "Ambient",
             "created_at": "2016-09-27T13:10:46+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-12-04T12:29:21+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -12483,17 +8053,7 @@
             "zone": null,
             "created_at": "2016-07-28T12:50:05+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T10:10:34+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -12519,28 +8079,8 @@
             "zone": "Ambient",
             "created_at": "2017-05-08T12:23:52+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T12:25:15+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T12:25:15+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -12566,17 +8106,7 @@
             "zone": null,
             "created_at": "2016-10-13T09:24:17+01:00",
             "categories": [
-                {
-                    "id": "384da59c-9452-11e6-87b0-06981aa90cf9",
-                    "title": "Christmas",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-10-17T11:34:18+01:00"
-                    }
-                }
+                "384da59c-9452-11e6-87b0-06981aa90cf9"
             ],
             "tags": [],
             "images": {
@@ -12602,17 +8132,7 @@
             "zone": "Ambient",
             "created_at": "2017-08-08T16:39:57+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-08-08T16:40:29+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -12638,28 +8158,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:35:09+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:35:23+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:35:23+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -12685,39 +8185,9 @@
             "zone": "Ambient",
             "created_at": "2016-10-13T09:10:08+01:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-10-13T10:40:02+01:00"
-                    }
-                },
-                {
-                    "id": "830f0a62-3854-11e6-8999-06f9522b85fb",
-                    "title": "Large BakedIn",
-                    "box_limit": 1,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-10-13T10:40:02+01:00"
-                    }
-                },
-                {
-                    "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
-                    "title": "Kids",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-19T15:28:23+00:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "830f0a62-3854-11e6-8999-06f9522b85fb",
+                "c2b64b58-5280-11e6-b304-02cd0b1dc697"
             ],
             "tags": [],
             "images": {
@@ -12743,17 +8213,7 @@
             "zone": null,
             "created_at": "2016-08-30T09:55:11+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-09-07T13:26:22+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -12779,17 +8239,7 @@
             "zone": null,
             "created_at": "2016-06-15T10:56:42+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-07-05T13:46:48+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -12835,17 +8285,7 @@
             "zone": null,
             "created_at": "2016-08-16T13:03:38+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T10:13:16+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -12871,28 +8311,8 @@
             "zone": "Ambient",
             "created_at": "2019-06-21T10:13:36+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-06-21T10:13:59+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-06-21T10:13:59+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -12918,17 +8338,7 @@
             "zone": null,
             "created_at": "2016-05-10T13:26:50+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T12:16:14+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -12954,28 +8364,8 @@
             "zone": null,
             "created_at": "2017-09-05T11:20:34+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-06T15:27:38+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-09-06T15:27:38+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -13001,17 +8391,7 @@
             "zone": null,
             "created_at": "2017-11-03T17:38:50+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-12-29T15:14:10+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -13037,28 +8417,8 @@
             "zone": null,
             "created_at": "2016-05-25T11:43:09+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-30T10:03:00+00:00"
-                    }
-                },
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T12:16:26+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -13084,39 +8444,9 @@
             "zone": null,
             "created_at": "2017-03-06T10:51:32+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T12:02:31+00:00"
-                    }
-                },
-                {
-                    "id": "830f0a62-3854-11e6-8999-06f9522b85fb",
-                    "title": "Large BakedIn",
-                    "box_limit": 1,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-03-06T12:02:31+00:00"
-                    }
-                },
-                {
-                    "id": "c2b64b58-5280-11e6-b304-02cd0b1dc697",
-                    "title": "Kids",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-19T15:28:14+00:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "830f0a62-3854-11e6-8999-06f9522b85fb",
+                "c2b64b58-5280-11e6-b304-02cd0b1dc697"
             ],
             "tags": [],
             "images": {
@@ -13164,28 +8494,8 @@
             "zone": "Ambient",
             "created_at": "2016-03-31T08:52:14+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:58:05+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-25T10:58:05+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -13211,17 +8521,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:19:37+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -13243,17 +8543,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:17:43+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -13275,17 +8565,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:21:19+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -13307,17 +8587,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:20:47+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -13339,17 +8609,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:19:51+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -13371,28 +8631,8 @@
             "zone": null,
             "created_at": "2017-11-03T14:11:22+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-12-29T15:14:47+00:00"
-                    }
-                },
-                {
-                    "id": "dd25600c-97c9-11e7-b173-067ba2f0c390",
-                    "title": "Free from",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-11-14T12:50:36+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "dd25600c-97c9-11e7-b173-067ba2f0c390"
             ],
             "tags": [],
             "images": {
@@ -13418,17 +8658,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:21:53+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -13450,17 +8680,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:18:03+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -13482,17 +8702,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:20:05+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -13514,17 +8724,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:20:34+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -13546,17 +8746,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:22:07+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -13578,28 +8768,8 @@
             "zone": "Chilled",
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T13:49:27+01:00"
-                    }
-                },
-                {
-                    "id": "8302b6ae-3854-11e6-9e42-06f9522b85fb",
-                    "title": "Little Pot",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-17T13:49:27+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "8302b6ae-3854-11e6-9e42-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -13625,28 +8795,8 @@
             "zone": "Ambient",
             "created_at": "2019-07-23T17:42:34+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:42:55+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-07-23T17:42:55+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -13672,28 +8822,8 @@
             "zone": "Chilled",
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T13:49:44+01:00"
-                    }
-                },
-                {
-                    "id": "8302b6ae-3854-11e6-9e42-06f9522b85fb",
-                    "title": "Little Pot",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-17T13:49:44+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "8302b6ae-3854-11e6-9e42-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -13719,17 +8849,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-01-20T14:00:28+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -13755,28 +8875,8 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:00:19+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:00:19+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -13802,28 +8902,8 @@
             "zone": "Ambient",
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:01:42+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:01:42+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -13849,28 +8929,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T15:20:54+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T15:21:19+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-20T15:21:19+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -13896,39 +8956,9 @@
             "zone": "Ambient",
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:01:54+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:01:54+01:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-30T10:45:43+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -13954,28 +8984,8 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:02:13+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:02:13+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -14001,28 +9011,8 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:00:46+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:00:46+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -14044,28 +9034,8 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:04:58+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:04:58+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -14087,39 +9057,9 @@
             "zone": "Ambient",
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:04:46+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:04:46+01:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T16:53:50+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -14145,28 +9085,8 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T14:12:20+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-09-13T08:57:53+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -14192,28 +9112,8 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:04:18+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:04:18+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -14235,28 +9135,8 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:04:02+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:04:02+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -14282,28 +9162,8 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:03:34+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:03:34+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -14329,28 +9189,8 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:03:17+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-12T13:03:17+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -14372,17 +9212,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:20:22+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -14404,17 +9234,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T09:24:25+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -14440,28 +9260,8 @@
             "zone": "Chilled",
             "created_at": "2017-05-08T16:13:21+01:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-09-25T14:58:45+01:00"
-                    }
-                },
-                {
-                    "id": "dd25600c-97c9-11e7-b173-067ba2f0c390",
-                    "title": "Free from",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-09-19T10:57:27+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "dd25600c-97c9-11e7-b173-067ba2f0c390"
             ],
             "tags": [],
             "images": {
@@ -14487,28 +9287,8 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-09T16:49:20+01:00"
-                    }
-                },
-                {
-                    "id": "384da59c-9452-11e6-87b0-06981aa90cf9",
-                    "title": "Christmas",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-10-18T15:39:05+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "384da59c-9452-11e6-87b0-06981aa90cf9"
             ],
             "tags": [],
             "images": {
@@ -14534,17 +9314,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-24T10:46:44+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -14570,17 +9340,7 @@
             "zone": "Ambient",
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T13:52:37+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -14606,17 +9366,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-05-12T09:10:46+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -14642,17 +9392,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:21:32+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -14674,17 +9414,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:21:41+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -14706,17 +9436,7 @@
             "zone": "Ambient",
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-22T13:40:00+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -14742,17 +9462,7 @@
             "zone": "Ambient",
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-22T13:40:19+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -14778,17 +9488,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-13T08:57:29+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -14810,17 +9510,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-14T10:24:13+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -14846,17 +9536,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-14T10:24:44+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -14882,17 +9562,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-13T08:58:24+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -14918,28 +9588,8 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:19:22+01:00"
-                    }
-                },
-                {
-                    "id": "831b3f8a-3854-11e6-86cf-06f9522b85fb",
-                    "title": "Small BakedIn",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-10-05T10:05:19+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "831b3f8a-3854-11e6-86cf-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -14965,28 +9615,8 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T16:51:50+01:00"
-                    }
-                },
-                {
-                    "id": "83281818-3854-11e6-8771-06f9522b85fb",
-                    "title": "Mug BakedIn",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-16T16:51:50+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "83281818-3854-11e6-8771-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -15012,17 +9642,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:17:12+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15044,17 +9664,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:21:02+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15076,17 +9686,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:17:27+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15108,17 +9708,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-27T16:18:16+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15140,17 +9730,7 @@
             "zone": "Ambient",
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T15:46:58+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15176,17 +9756,7 @@
             "zone": null,
             "created_at": "2016-07-28T12:50:35+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T10:12:27+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15212,17 +9782,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-22T13:44:08+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15248,28 +9808,8 @@
             "zone": null,
             "created_at": "2017-11-03T13:42:47+00:00",
             "categories": [
-                {
-                    "id": "384da59c-9452-11e6-87b0-06981aa90cf9",
-                    "title": "Christmas",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-11-08T17:08:00+00:00"
-                    }
-                },
-                {
-                    "id": "47d0e046-d12e-11e7-aba4-0617e74d8914",
-                    "title": "Christmas sm",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-11-24T15:50:01+00:00"
-                    }
-                }
+                "384da59c-9452-11e6-87b0-06981aa90cf9",
+                "47d0e046-d12e-11e7-aba4-0617e74d8914"
             ],
             "tags": [],
             "images": {
@@ -15295,17 +9835,7 @@
             "zone": "Ambient",
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-04-12T12:43:36+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15331,17 +9861,7 @@
             "zone": "Ambient",
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T14:03:08+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15367,17 +9887,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-07-05T13:42:31+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15403,17 +9913,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T14:03:24+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15439,17 +9939,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-05T11:39:38+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15475,17 +9965,7 @@
             "zone": null,
             "created_at": "2016-01-20T14:30:00+00:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-04-22T08:36:40+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15511,17 +9991,7 @@
             "zone": null,
             "created_at": "2016-03-31T15:40:23+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T09:24:42+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15547,28 +10017,8 @@
             "zone": "Chilled",
             "created_at": "2018-11-09T14:51:04+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-09T14:52:10+00:00"
-                    }
-                },
-                {
-                    "id": "8302b6ae-3854-11e6-9e42-06f9522b85fb",
-                    "title": "Little Pot",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-09T14:52:10+00:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "8302b6ae-3854-11e6-9e42-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -15638,17 +10088,7 @@
             "zone": null,
             "created_at": "2018-01-23T17:28:57+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-01-26T11:16:40+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15674,17 +10114,7 @@
             "zone": null,
             "created_at": "2016-02-03T11:04:28+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T12:24:02+01:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15710,28 +10140,8 @@
             "zone": null,
             "created_at": "2016-11-14T11:24:24+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-11-14T11:31:19+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-02-09T15:25:04+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -15757,28 +10167,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T16:39:49+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T16:40:12+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-20T16:40:12+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -15804,28 +10194,8 @@
             "zone": null,
             "created_at": "2017-05-08T13:36:02+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:36:34+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T13:36:34+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -15851,17 +10221,7 @@
             "zone": "Ambient",
             "created_at": "2019-08-12T16:14:36+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-12T16:14:58+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15887,17 +10247,7 @@
             "zone": null,
             "created_at": "2016-06-28T10:56:00+01:00",
             "categories": [
-                {
-                    "id": "4cb35a02-27da-11e6-bf1e-026e15ef4a55",
-                    "title": "Lunch",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-16T12:24:19+01:00"
-                    }
-                }
+                "4cb35a02-27da-11e6-bf1e-026e15ef4a55"
             ],
             "tags": [],
             "images": {
@@ -15923,17 +10273,7 @@
             "zone": "Ambient",
             "created_at": "2017-03-29T11:17:23+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-31T14:26:41+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -15959,28 +10299,8 @@
             "zone": null,
             "created_at": "2017-11-28T17:31:02+00:00",
             "categories": [
-                {
-                    "id": "384da59c-9452-11e6-87b0-06981aa90cf9",
-                    "title": "Christmas",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-11-28T17:32:19+00:00"
-                    }
-                },
-                {
-                    "id": "4dd32756-d12e-11e7-b28b-0617e74d8914",
-                    "title": "Christmas md",
-                    "box_limit": 3,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-12-05T12:31:18+00:00"
-                    }
-                }
+                "384da59c-9452-11e6-87b0-06981aa90cf9",
+                "4dd32756-d12e-11e7-b28b-0617e74d8914"
             ],
             "tags": [],
             "images": {
@@ -16006,17 +10326,7 @@
             "zone": "Ambient",
             "created_at": "2019-08-09T10:20:18+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-09T10:21:32+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -16042,28 +10352,8 @@
             "zone": "Ambient",
             "created_at": "2017-05-08T12:24:33+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T12:26:39+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T12:26:39+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -16089,28 +10379,8 @@
             "zone": null,
             "created_at": "2016-05-25T11:43:37+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-30T10:03:14+00:00"
-                    }
-                },
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-12-19T09:47:34+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -16160,28 +10430,8 @@
             "zone": "Ambient",
             "created_at": "2018-03-13T14:36:32+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-13T14:37:05+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-03-13T14:37:05+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -16207,28 +10457,8 @@
             "zone": "Ambient",
             "created_at": "2017-03-06T10:59:09+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:53:45+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-03-06T11:53:45+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -16254,17 +10484,7 @@
             "zone": "Ambient",
             "created_at": "2016-07-27T13:06:27+01:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T13:56:53+01:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -16290,17 +10510,7 @@
             "zone": null,
             "created_at": "2016-06-15T10:57:18+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-07-05T13:46:39+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -16326,28 +10536,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T14:59:49+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T15:00:38+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-20T15:00:38+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -16373,28 +10563,8 @@
             "zone": null,
             "created_at": "2016-08-16T13:18:32+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-31T12:19:46+01:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-08-31T12:19:46+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -16420,28 +10590,8 @@
             "zone": null,
             "created_at": "2017-11-08T16:07:35+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-12-29T15:15:32+00:00"
-                    }
-                },
-                {
-                    "id": "830f0a62-3854-11e6-8999-06f9522b85fb",
-                    "title": "Large BakedIn",
-                    "box_limit": 1,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-12-29T15:15:32+00:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "830f0a62-3854-11e6-8999-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -16467,17 +10617,7 @@
             "zone": "Ambient",
             "created_at": "2018-10-26T09:48:40+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-10-26T09:51:22+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -16503,28 +10643,8 @@
             "zone": null,
             "created_at": "2017-03-06T10:52:07+00:00",
             "categories": [
-                {
-                    "id": "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
-                    "title": "Desserts",
-                    "box_limit": 4,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-06T12:03:03+00:00"
-                    }
-                },
-                {
-                    "id": "830f0a62-3854-11e6-8999-06f9522b85fb",
-                    "title": "Large BakedIn",
-                    "box_limit": 1,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-03-06T12:03:03+00:00"
-                    }
-                }
+                "fec10d0e-bf7d-11e5-90a9-02fada0dd3b9",
+                "830f0a62-3854-11e6-8999-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -16550,17 +10670,7 @@
             "zone": "Ambient",
             "created_at": "2019-09-10T10:04:06+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-09-10T10:48:33+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -16586,28 +10696,8 @@
             "zone": "Ambient",
             "created_at": "2018-03-13T16:38:22+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-03-13T16:38:48+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-03-13T16:38:48+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -16633,28 +10723,8 @@
             "zone": "Ambient",
             "created_at": "2017-05-08T17:46:56+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-05-08T17:47:11+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-05-08T17:47:11+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -16680,28 +10750,8 @@
             "zone": null,
             "created_at": "2017-01-19T17:59:00+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-19T18:00:09+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2017-01-19T18:00:09+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -16747,28 +10797,8 @@
             "zone": "Ambient",
             "created_at": "2019-08-09T12:29:39+01:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-08-09T12:29:57+01:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2019-08-09T12:29:57+01:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -16794,17 +10824,7 @@
             "zone": "Ambient",
             "created_at": "2016-03-31T15:41:04+01:00",
             "categories": [
-                {
-                    "id": "529ea59e-bf7e-11e5-840e-02fada0dd3b9",
-                    "title": "Kitchenware",
-                    "box_limit": 6,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-17T14:04:01+01:00"
-                    }
-                }
+                "529ea59e-bf7e-11e5-840e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -16852,28 +10872,8 @@
             "zone": "Ambient",
             "created_at": "2018-11-20T16:04:38+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2018-11-20T16:05:03+00:00"
-                    }
-                },
-                {
-                    "id": "785741fc-3854-11e6-87a5-06f9522b85fb",
-                    "title": "Large Alcohol",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2018-11-20T16:05:03+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "785741fc-3854-11e6-87a5-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -16899,28 +10899,8 @@
             "zone": null,
             "created_at": "2017-01-19T17:52:02+00:00",
             "categories": [
-                {
-                    "id": "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
-                    "title": "Snacks",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-01-19T17:54:16+00:00"
-                    }
-                },
-                {
-                    "id": "a44b4c22-e489-11e6-9d77-027ca04bdf39",
-                    "title": "Most Popular",
-                    "box_limit": 2,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2017-03-13T09:57:42+00:00"
-                    }
-                }
+                "17eb3f8e-bf7e-11e5-ab63-02fada0dd3b9",
+                "a44b4c22-e489-11e6-9d77-027ca04bdf39"
             ],
             "tags": [],
             "images": {
@@ -16946,28 +10926,8 @@
             "zone": null,
             "created_at": "2016-11-14T11:25:02+00:00",
             "categories": [
-                {
-                    "id": "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
-                    "title": "Drinks Cabinet",
-                    "box_limit": 7,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-11-14T11:27:52+00:00"
-                    }
-                },
-                {
-                    "id": "7867356c-3854-11e6-ab35-06f9522b85fb",
-                    "title": "Mini Alcohol",
-                    "box_limit": 5,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": true,
-                    "pivot": {
-                        "created_at": "2016-11-15T14:21:51+00:00"
-                    }
-                }
+                "faeedf8a-bf7d-11e5-a0f9-02fada0dd3b9",
+                "7867356c-3854-11e6-ab35-06f9522b85fb"
             ],
             "tags": [],
             "images": {
@@ -16993,17 +10953,7 @@
             "zone": "Ambient",
             "created_at": "2019-02-18T12:30:36+00:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2019-02-18T15:31:17+00:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {
@@ -17051,17 +11001,7 @@
             "zone": null,
             "created_at": "2016-08-05T09:43:01+01:00",
             "categories": [
-                {
-                    "id": "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9",
-                    "title": "Food Cupboard",
-                    "box_limit": 10,
-                    "is_default": false,
-                    "recently_added": false,
-                    "hidden": false,
-                    "pivot": {
-                        "created_at": "2016-08-30T09:56:48+01:00"
-                    }
-                }
+                "01b06fa0-bf7e-11e5-9c1e-02fada0dd3b9"
             ],
             "tags": [],
             "images": {


### PR DESCRIPTION
Rather than storing all category info in two places, only store the ID against products